### PR TITLE
Include node modules in built docker container

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,1 +1,0 @@
-**/node_modules


### PR DESCRIPTION
For caching purposes, include the node modules from the container